### PR TITLE
[FEAT] 비밀번호 찾기 페이지 마크업

### DIFF
--- a/assets/scss/global.pcss
+++ b/assets/scss/global.pcss
@@ -20,36 +20,43 @@ body {
   /* font-family: "NotoSansKR-Regular"; */
 }
 
+/* 45px */
 .txt-heading1 {
   font-family: "NotoSansKR-Bold";
   font-size: 2.8125rem;
 }
 
+/* 38px */
 .txt-heading2 {
   font-family: "NotoSansKR-Bold";
   font-size: 2.375rem;
 }
 
+/* 28px */
 .txt-heading3 {
   font-family: "NotoSansKR-Bold";
   font-size: 1.75rem;
 }
 
+/* 20px */
 .txt-mid-bold {
   font-family: "NotoSansKR-Bold";
   font-size: 1.25rem;
 }
 
+/* 20px */
 .txt-mid {
   font-family: "NotoSansKR-Regular";
   font-size: 1.25rem;
 }
 
+/* 16px */
 .txt-base {
   font-family: "NotoSansKR-Regular";
   font-size: 1rem;
 }
 
+/* 14px */
 .txt-sub {
   font-family: "NotoSansKR-Regular";
   font-size: 0.875rem;

--- a/components/homeLayer/header.vue
+++ b/components/homeLayer/header.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="fixed top-0 w-full bg-white border-b-2">
+  <nav class="fixed top-0 z-50 w-full bg-white border-b-2">
     <div class="relative flex items-center mx-auto nav-content-wrapper-size">
       <!-- content--left -->
       <div class="absolute left-0 h-full test">

--- a/components/input/general.vue
+++ b/components/input/general.vue
@@ -1,0 +1,39 @@
+<template>
+  <input
+    :value="value"
+    @input="handleInput"
+    type="text"
+    class="w-full px-3 py-4 mt-8 border-2 rounded-base focus:outline-none"
+    :class="{ 'border-black': value.length > 0 }"
+    :style="`${height}px`"
+  />
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+export default Vue.extend({
+  props: {
+    value: {
+      type: String,
+      required: true,
+    },
+    width: {
+      type: Number,
+    },
+    height: {
+      type: Number,
+      default: () => 56,
+    },
+    placeholder: {
+      type: String,
+    },
+  },
+  methods: {
+    handleInput(event: InputEvent) {
+      const eventTarget = event.target as HTMLInputElement;
+      this.$emit("input", eventTarget.value);
+    },
+  },
+});
+</script>

--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <HomeLayerHeader />
-    <Nuxt />
+    <div style="padding-top: 82px">
+      <Nuxt />
+    </div>
   </div>
 </template>

--- a/pages/forgotpassword.vue
+++ b/pages/forgotpassword.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="flex justify-center mt-30">
+    <div style="width: 380px">
+      <h3 class="text-center txt-heading3">비밀번호 찾기</h3>
+      <p class="mt-8">가입한 이메일로 임시 비밀번호를 보내드려요!</p>
+      <p>이메일 주소를 입력해주세요.</p>
+      <inputGeneral :value="userEmail" @input="updateInput" :height="56" />
+      <buttonGeneral :large="true" :height="56" btnText="확인" class="mt-8" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+export default Vue.extend({
+  layout: "home",
+  data() {
+    return {
+      userEmail: "",
+    };
+  },
+  methods: {
+    updateInput(value: string) {
+      this.userEmail = value;
+    },
+  },
+});
+</script>
+
+<style lang="postcss" scoped></style>

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex justify-center mt-32 md:mb-24 lg:mb-0">
+  <div class="flex justify-center mt-32 md:mb-24">
     <div class="relative flex flex-col test" style="width: 380px">
       <h3 class="text-center txt-heading3">회원가입</h3>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,12 @@ module.exports = {
         green1: "#49BC93",
         gray1: "#868E96",
       },
+      spacing: {
+        30: "120px",
+      },
+      borderRadius: {
+        base: "4px",
+      },
     },
   },
   variants: {


### PR DESCRIPTION
## 📌 개요

- #16 

## 👩‍💻 작업 사항

- [x] global pcss 파일 각 폰트타입에 해당픽셀 주석추가
- [x] transparent wrapper input component 생성
- [x] 비밀번호찾기 페이지 마크업 생성
- [x] signup 페이지 lg일떄 마진설정 제거
- [x] nuxt router view 영역에 header크기만큼 padding top설정
- [x] header에 z-index 설정

## ✅ 참고 사항

-
