### PR TITLE
[FIX] freetopic index page에서 pagination설정후 뒤로가기나 새로고침시 pagination idx가 변하지 않는 버그 수정

### DIFF
--- a/pages/community/freetopic/index.vue
+++ b/pages/community/freetopic/index.vue
@@ -186,7 +186,9 @@ export default {
     }
     totalPageNum = Math.ceil(Number(pageCountResponse.data["num_talk"]) / 16);
 
-    return { freeTopicData, currentMenuIdx, totalPageNum };
+    let pageIdx = Number(page) - 1;
+
+    return { freeTopicData, currentMenuIdx, totalPageNum, pageIdx };
   },
   data() {
     return {
@@ -225,6 +227,7 @@ export default {
 
       this.getFreeTopicData();
       this.getTotalPageNum();
+      this.pageIdx = Number(page) - 1;
     },
   },
   methods: {


### PR DESCRIPTION
## 📌 개요

- #232 

## 👩‍💻 작업 사항

- [x] freetopic index page에서 pagination설정후 뒤로가기나 새로고침시 pagination idx가 변하지 않는 버그 수정

## ✅ 참고 사항

-
